### PR TITLE
update to hapi-fhir-0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <slf4jLog4j12Version>1.6.0</slf4jLog4j12Version>
         <xmlStreamVersion>1.0-2</xmlStreamVersion>
         <SaxonHEVersion>9.4</SaxonHEVersion>
-        <hapiFhirBaseVersion>0.9-SNAPSHOT</hapiFhirBaseVersion>
-        <hapiFhirStructuresDstuVersion>0.9-SNAPSHOT</hapiFhirStructuresDstuVersion>
+        <hapiFhirBaseVersion>0.9</hapiFhirBaseVersion>
+        <hapiFhirStructuresDstuVersion>0.9</hapiFhirStructuresDstuVersion>
         <thymeleafVersion>2.1.4.RELEASE</thymeleafVersion>
         <phlocSchematronVersion>2.7.1</phlocSchematronVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
We need to use 0.9, or else the (DSTU2 based) searchset wont work :-)