### PR TITLE
typo fixed, to Person is not found for the given Id

### DIFF
--- a/omod/src/main/java/org/openmrs/module/fhir/resources/FHIRPersonResource.java
+++ b/omod/src/main/java/org/openmrs/module/fhir/resources/FHIRPersonResource.java
@@ -29,7 +29,7 @@ public class FHIRPersonResource extends Resource {
 		PersonService personService = Context.getService(PersonService.class);
 		Person fhirPerson = personService.getPerson(id.getIdPart());
 		if (fhirPerson == null) {
-			throw new ResourceNotFoundException("Practitioner is not found for the given Id " + id.getIdPart());
+			throw new ResourceNotFoundException("Person is not found for the given Id " + id.getIdPart());
 		}
 		return fhirPerson;
 	}


### PR DESCRIPTION
"Practitioner is not found for the given Id  " into "Person is not found for the given Id "