### PR TITLE
Call FHIRObsUtil to store Obs sent via the DiagnosticReport

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir/api/diagnosticreport/handler/LaboratoryHandler.java
+++ b/api/src/main/java/org/openmrs/module/fhir/api/diagnosticreport/handler/LaboratoryHandler.java
@@ -239,7 +239,7 @@ public class LaboratoryHandler extends AbstractHandler implements DiagnosticRepo
 		for(IResource resource :containedResources.getContainedResources()){
 			if(resource.getResourceName().equals("Observation")){
 				ObsService fhirObsService = Context.getService(ObsService.class);
-
+				fhirObsService.createFHIRObservation((Observation)resource);
 			}
 		}
 		diagnosticReport.setId(new IdDt("DiagnosticReport", omrsEncounter.getUuid()));

--- a/api/src/main/java/org/openmrs/module/fhir/api/diagnosticreport/handler/LaboratoryHandler.java
+++ b/api/src/main/java/org/openmrs/module/fhir/api/diagnosticreport/handler/LaboratoryHandler.java
@@ -1,8 +1,11 @@
 package org.openmrs.module.fhir.api.diagnosticreport.handler;
 
+import ca.uhn.fhir.model.api.IResource;
 import ca.uhn.fhir.model.dstu2.composite.AttachmentDt;
 import ca.uhn.fhir.model.dstu2.composite.CodingDt;
+import ca.uhn.fhir.model.dstu2.composite.ContainedDt;
 import ca.uhn.fhir.model.dstu2.resource.DiagnosticReport;
+import ca.uhn.fhir.model.dstu2.resource.Observation;
 import ca.uhn.fhir.model.dstu2.resource.Patient;
 import ca.uhn.fhir.model.dstu2.resource.Practitioner;
 import ca.uhn.fhir.model.primitive.Base64BinaryDt;
@@ -20,6 +23,7 @@ import org.openmrs.Provider;
 import org.openmrs.api.APIException;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.fhir.api.ObsService;
 import org.openmrs.module.fhir.api.PatientService;
 import org.openmrs.module.fhir.api.PractitionerService;
 import org.openmrs.module.fhir.api.diagnosticreport.DiagnosticReportHandler;
@@ -231,6 +235,13 @@ public class LaboratoryHandler extends AbstractHandler implements DiagnosticRepo
 		}
 		//TODO: Is it necessary?  omrsDiagnosticReport.setObs(obsList);
 
+		ContainedDt containedResources = diagnosticReport.getContained();
+		for(IResource resource :containedResources.getContainedResources()){
+			if(resource.getResourceName().equals("Observation")){
+				ObsService fhirObsService = Context.getService(ObsService.class);
+
+			}
+		}
 		diagnosticReport.setId(new IdDt("DiagnosticReport", omrsEncounter.getUuid()));
 		return diagnosticReport;
 	}

--- a/api/src/main/java/org/openmrs/module/fhir/api/util/FHIRObsUtil.java
+++ b/api/src/main/java/org/openmrs/module/fhir/api/util/FHIRObsUtil.java
@@ -256,11 +256,9 @@ public class FHIRObsUtil {
 			errors.add("Subject cannot be null");
 		}
 		
-		DateTimeDt dateApplies = (DateTimeDt) observation.getApplies();
-		obs.setObsDatetime(dateApplies.getValue());
-		
-		Date instant = observation.getIssued();
-		obs.setDateCreated(instant);
+		Date dateIssued = observation.getIssued();
+		obs.setObsDatetime(dateIssued);
+		obs.setDateCreated(new Date());
 		
 		String conceptCode = null;
 		String system = null;


### PR DESCRIPTION
Hi @milankarunarathne , @harsha89 , here's the change that you need to store obs sent as contained resources. I also got rid of date applies, which is deprecated in FHIR DSTU2.

The sample diagnostic report that I used can be seen at https://gist.github.com/surangak/b64a5e866bbd27e13222

You'll see minute differences that the sample you've been using in this.

Also note that this is not complete - for example, i'm not linking the  newly created obs to an  encounter here :-(