### PR TITLE
Create with uuid through FHIR

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir/api/client/Client.java
+++ b/api/src/main/java/org/openmrs/module/fhir/api/client/Client.java
@@ -8,24 +8,24 @@ import org.springframework.http.ResponseEntity;
 public interface Client {
 
     /**
-     * Perform GET request.
+     * Retrieve object from remote server.
      *
      * @param category Category of the resource.
      * @param url The url of the resource.
      * @param username Username for Basic Auth.
      * @param password Password for Basic Auth.
-     * @return Object representing pulled object.
+     * @return Object representing retrieved object.
      */
-    Object getObject(String category, String url, String username, String password);
+    Object retrieveObject(String category, String url, String username, String password);
 
     /**
-     * Perform POST request.
+     * Create object on remote server.
      *
      * @param url The url of the resource.
      * @param username Username for Basic Auth.
      * @param password Password for Baisc Auth.
-     * @param object Object to be send.
+     * @param object Object to be sent.
      * @return Response entity representing request result.
      */
-    ResponseEntity<String> postObject(String url, String username, String password, Object object);
+    ResponseEntity<String> createObject(String url, String username, String password, Object object);
 }

--- a/api/src/main/java/org/openmrs/module/fhir/api/client/FHIRClient.java
+++ b/api/src/main/java/org/openmrs/module/fhir/api/client/FHIRClient.java
@@ -6,6 +6,8 @@ import org.apache.commons.logging.LogFactory;
 import org.hl7.fhir.dstu3.model.Location;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -49,7 +51,7 @@ public class FHIRClient implements Client {
             throws RestClientException {
         prepareRestTemplate(username, password);
         IBaseResource baseResource = (IBaseResource) object;
-        return restTemplate.postForEntity(url, baseResource, String.class);
+        return restTemplate.exchange(url, HttpMethod.PUT, new HttpEntity<Object>(baseResource), String.class);
     }
 
     private void prepareRestTemplate(String username, String password) {

--- a/api/src/main/java/org/openmrs/module/fhir/api/client/FHIRClient.java
+++ b/api/src/main/java/org/openmrs/module/fhir/api/client/FHIRClient.java
@@ -40,17 +40,18 @@ public class FHIRClient implements Client {
     }
 
     @Override
-    public Object getObject(String category, String url, String username, String password)
+    public Object retrieveObject(String category, String url, String username, String password)
             throws RestClientException {
         prepareRestTemplate(username, password);
         return restTemplate.getForObject(url, resolveCategory(category));
     }
 
     @Override
-    public ResponseEntity<String> postObject(String url, String username, String password, Object object)
+    public ResponseEntity<String> createObject(String url, String username, String password, Object object)
             throws RestClientException {
         prepareRestTemplate(username, password);
         IBaseResource baseResource = (IBaseResource) object;
+        url = url + "/" + baseResource.getIdElement().getIdPart();
         return restTemplate.exchange(url, HttpMethod.PUT, new HttpEntity<Object>(baseResource), String.class);
     }
 


### PR DESCRIPTION
Changed naming convention in Client interface to follow [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete)

I changed create method to use Http PUT with uuid in t he url. The reason lies in:
https://github.com/jamesagnew/hapi-fhir/blob/fe37c87e78f43a737fc103fa24d3344002618990/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseOutcomeReturningMethodBindingWithResourceParam.java#L104

Basically, starting from DSTU3 the uuid is taken from url parameter.
 